### PR TITLE
[FIX] Removing unused REPORT_ANALYTICS message type from action types

### DIFF
--- a/src/content-script/content-script.ts
+++ b/src/content-script/content-script.ts
@@ -7,9 +7,6 @@ const gamkenbot = new Gamkenbot();
 
 browser.runtime.onMessage.addListener((message: PlatformMessage) => {
   match(message)
-    .with({ action: ActionTypes.ReportAnalytics }, ({ payload }) => {
-      console.log(payload);
-    })
     .with({ action: ActionTypes.IsLoggedIn }, gamkenbot.setLoggedIn)
     .with({ action: ActionTypes.StartSearch }, gamkenbot.startSearching)
     .with({ action: ActionTypes.StopSearch }, gamkenbot.stopSearching)

--- a/src/platform-message.ts
+++ b/src/platform-message.ts
@@ -2,7 +2,6 @@ export enum ActionTypes {
   IsLoggedIn = 'IS_LOGGED_IN',
   StartSearch = 'START_SEARCH',
   StopSearch = 'STOP_SEARCH',
-  ReportAnalytics = 'REPORT_ANALYTICS',
 }
 
 interface IsLoggedInMessage {


### PR DESCRIPTION
## Description

Build failed because of unused type which got partly deleted


## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Passes `npm run build` locally
